### PR TITLE
Error improvements

### DIFF
--- a/__tests__/error.ts
+++ b/__tests__/error.ts
@@ -1,0 +1,75 @@
+// tslint:disable-next-line no-import-side-effect
+import "isomorphic-fetch";
+import { map, range } from "lodash";
+
+import { makeFakeResponse } from "./fixtures";
+
+import { FetchError, FetchyError } from "../src/utils/error";
+
+describe("FecthyError responses validation", () => {
+
+    test("All failed responses", () => {
+
+        const e = new FetchyError(
+            "some msg",
+            map(range(5), () => makeFakeResponse(false)),
+        );
+        expect(e).toBeDefined();
+        expect(e).toBeInstanceOf(FetchyError);
+
+        expect(e.hasResponses()).toBe(true);
+        expect(e.hasErrors()).toBe(false);
+        expect(e.responses).toHaveLength(5);
+
+    });
+
+    test("A not failed response", () => {
+
+        const responses = map(range(5), () => makeFakeResponse(false));
+        responses.push(makeFakeResponse(true));
+
+        expect(() =>
+            new FetchyError(
+                "some msg",
+                responses,
+            ),
+        ).toThrow("One or more responses is not failed.");
+
+    });
+
+});
+
+describe("FecthyError errors validation", () => {
+
+        test("All errors", () => {
+
+            const e = new FetchyError(
+                "some msg",
+                undefined,
+                map(range(5), () => new Error("some msg")),
+            );
+            expect(e).toBeDefined();
+            expect(e).toBeInstanceOf(FetchyError);
+
+            expect(e.hasErrors()).toBe(true);
+            expect(e.hasResponses()).toBe(false);
+            expect(e.errors).toHaveLength(5);
+
+        });
+
+        test("A not failed response", () => {
+
+            const errors = map(range(5), () => new Error("some msg"));
+            errors.push(null);
+
+            expect(() =>
+                new FetchyError(
+                    "some msg",
+                    undefined,
+                    errors,
+                ),
+            ).toThrow("One or more errors is not instance of Error.");
+
+        });
+
+    });

--- a/__tests__/fetch.ts
+++ b/__tests__/fetch.ts
@@ -1,0 +1,32 @@
+import { FetchyError } from "../src/utils/error";
+import { customFetch } from "../src/utils/fetch";
+
+describe("Custom Fetch errors", () => {
+
+    test("404 => !response.ok", () => {
+        expect.assertions(4);
+
+        return customFetch("http://lorenzosavini.com/404")
+            .catch((e: FetchyError) => {
+
+                expect(e).toBeInstanceOf(FetchyError);
+                expect(e.hasResponses()).toBe(true);
+                expect(e.response.ok).toBe(false);
+                expect(e.hasErrors()).toBe(false);
+            });
+    });
+
+    test("Newtork error", () => {
+        expect.assertions(4);
+
+        return customFetch("http://something.ext")
+            .catch((e: FetchyError) => {
+
+                expect(e).toBeInstanceOf(FetchyError);
+                expect(e.hasErrors()).toBe(true);
+                expect(e.error).toBeInstanceOf(TypeError);
+                expect(e.hasResponses()).toBe(false);
+            });
+    });
+
+});

--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -1,0 +1,17 @@
+// tslint:disable no-let no-any
+
+export const makeFakeResponse = (ok: boolean): Response => {
+
+    let msg: any = "";
+    let init: ResponseInit = {};
+    if (ok) {
+        msg = "some useless successful body";
+        init = { status: 200 };
+    } else {
+        msg = "some useless failed body";
+        init = { status: 500 };
+    }
+
+    return new Response(msg, init);
+
+};

--- a/__tests__/retry.ts
+++ b/__tests__/retry.ts
@@ -2,6 +2,7 @@ import {
     fetchy,
     IFetchyRetryMiddlewareConfig,
 } from "../src/fetchy";
+import { FetchyError } from "../src/utils/error";
 
 describe("Test retry logic", () => {
 
@@ -14,10 +15,11 @@ describe("Test retry logic", () => {
             retriableStatusCodes: (statusCode: number) => statusCode >= 400 && statusCode < 500,
             retryNetworkErrors: false,
         };
+
         return fetchy("http://lorenzosavini.com/404", {}, { middlewares: [], retry: retryConfig })
             .catch((e) => {
-                expect(e.message).toMatch(/failed 4 times/);
-                expect(e.name).toMatch("TypeError");
+                expect(e.message).toMatch("Too many failures.");
+                expect(e).toBeInstanceOf(FetchyError);
             });
 
     });
@@ -31,10 +33,11 @@ describe("Test retry logic", () => {
             retriableStatusCodes: (statusCode: number) => statusCode > 599,
             retryNetworkErrors: true,
         };
+
         return fetchy("http://something.ext", {}, { middlewares: [], retry: retryConfig })
             .catch((e) => {
-                expect(e.message).toMatch(/failed 4 times/);
-                expect(e.name).toMatch("TypeError");
+                expect(e.message).toMatch("Too many failures.");
+                expect(e).toBeInstanceOf(FetchyError);
             });
 
     });
@@ -45,10 +48,11 @@ describe("Default retry configuration", () => {
 
     test("Failure with client error", () => {
         expect.assertions(2);
+
         return fetchy("http://lorenzosavini.com/404", {}, { middlewares: [], retry: true })
             .catch((e) => {
-                expect(e.message).toMatch(/failed with 404/);
-                expect(e.name).toMatch("TypeError");
+                expect(e.message).toMatch("Fetch request failed with status 404");
+                expect(e).toBeInstanceOf(FetchyError);
             });
 
     });
@@ -58,7 +62,7 @@ describe("Default retry configuration", () => {
 
         return fetchy("http://something.ext", {}, { middlewares: [], retry: true })
             .catch((e) => {
-                expect(e.name).toMatch("TypeError");
+                expect(e).toBeInstanceOf(FetchyError);
             });
 
     });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    "testPathIgnorePatterns": ["<rootDir>/__tests__/fixtures.ts"],
     "transform": {
         "^.+\\.ts$": "<rootDir>/node_modules/ts-jest/preprocessor.js",
         "\\.js$": "<rootDir>/node_modules/babel-jest",

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,90 @@
+import { every, isNil, last, map, some } from "lodash";
+
+/*
+isomorphic-fecth uses node-fetch, which is not following
+the window.Fetch standard (which is for browsers).
+Instead, node-fetch raises FetchError.
+*/
+export type FetchError = Error;
+
+export class FetchyError extends Error {
+
+    private failedResponses: Response[] | null = null;
+    private realErrors: Error[] | null = null;
+
+    constructor(message: string, responses?: Response[], errors?: Error[]) {
+        super(message);
+
+        Object.setPrototypeOf(this, FetchyError.prototype);
+
+        if (!isNil(responses)) {
+            this.saveResponses(responses);
+        }
+        if (!isNil(errors)) {
+            this.saveErrors(errors);
+        }
+
+        if (!this.hasResponses() && !this.hasErrors()) {
+            throw new Error("Instances of FetchyError without response nor errors are not allowed.");
+        }
+    }
+
+    get responses(): Response[] | null {
+        return this.failedResponses;
+    }
+
+    get errors(): Error[] | null {
+        return this.realErrors;
+    }
+
+    get response(): Response {
+        if (!this.hasResponses()) {
+            throw new Error("No response to return. You should call this method after hasResponse");
+        }
+
+        return last(this.responses)!;
+    }
+
+    get error(): Error {
+        if (!this.hasErrors()) {
+            throw new Error("No error to return. You should call this method after hasErrors");
+        }
+
+        return last(this.errors)!;
+    }
+
+    public hasResponses(): boolean {
+        return this.failedResponses !== null
+            && this.failedResponses.length > 0;
+    }
+
+    public hasErrors(): boolean {
+        return this.realErrors !== null
+            && this.realErrors.length > 0;
+    }
+
+    private saveResponses(responses: Response[]): void {
+        if (some(map(responses, "ok"))) {
+            throw new Error("One or more responses is not failed.");
+        }
+
+        this.failedResponses = map(responses, (response) => response.clone());
+    }
+
+    private saveErrors(errors: Error[]): void {
+        if (!every(map(errors, (error: Error) => error instanceof Error))) {
+            throw new Error("One or more errors is not instance of Error.");
+        }
+
+        const normalizedErrors: Error[] = map(errors, (error: FetchError) => {
+            if (error.name === "FetchError") {
+                Object.setPrototypeOf(error, TypeError.prototype);
+                error.name = "TypeError";
+            }
+
+            return error;
+        });
+        this.realErrors = normalizedErrors;
+    }
+
+}


### PR DESCRIPTION
Bunch of improvements to the error that are thrown by fetchy:

- Now it always throws `FetchyError`s.
- FetchyError can contain both `Error`s or failed `Response`s.
- FetchyError can contain more than one error or response.
- FetchyError casts FetchError (from node-fetch) to TypeError (as Fetch standard)
- Retry logic throws a FetchyError with all the errors occurred
- customFetch is not 100% Fetch-compliant now, it throws FetchyErrors